### PR TITLE
Update install_metal.rb for using gems from upstream

### DIFF
--- a/test/cookbooks/lxctests/recipes/install_metal.rb
+++ b/test/cookbooks/lxctests/recipes/install_metal.rb
@@ -1,11 +1,9 @@
 include_recipe 'lxctests::install_lxc'
 
 chef_gem 'chef-metal' do
-  source '/mnt/host_src/chef-metal/pkg/chef-metal-0.8.gem'
-  version '0.8'
+        action :install
 end
 
 chef_gem 'chef-metal-lxc' do
-  source '/mnt/host_src/chef-metal-lxc/pkg/chef-metal-lxc-0.3.gem'
-  version '0.3'
+        action :install
 end


### PR DESCRIPTION
No need for specific gem version anymore.
