### PR TITLE
Fix to updated chef-metal gem named for vagrant

### DIFF
--- a/test/vagrant.rb
+++ b/test/vagrant.rb
@@ -1,5 +1,5 @@
 require 'cheffish'
-require 'chef_metal/vagrant'
+require 'chef_metal_vagrant'
 
 # Set up a vagrant cluster (place for vms) in ~/machinetest
 vagrant_cluster "#{File.dirname(__FILE__)}/machinetest"


### PR DESCRIPTION
This solve dummy error from instructions:

ERROR: cannot load such file -- chef_metal/vagrant
