### PR TITLE
Fix invalid requires

### DIFF
--- a/lib/chef/provisioning/driver_init/lxc.rb
+++ b/lib/chef/provisioning/driver_init/lxc.rb
@@ -1,3 +1,3 @@
-require 'chef/provisioning/lxc_driver/lxc_driver'
+require 'chef/provisioning/lxc_driver/driver'
 
 Chef::Provisioning.register_driver_class('lxc', Chef::Provisioning::LXCDriver::Driver)

--- a/lib/chef/provisioning/lxc_driver.rb
+++ b/lib/chef/provisioning/lxc_driver.rb
@@ -1,2 +1,2 @@
 require 'chef/provisioning'
-require 'chef/provisioning/lxc_driver/lxc_driver'
+require 'chef/provisioning/lxc_driver/driver'


### PR DESCRIPTION
- `lxc.rb` is called by `with_driver 'lxc'`
- `lxc_driver.rb` appears unused but made it match
