### PR TITLE
Support non-root containers. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
 source "https://rubygems.org"
 gemfile
 gemspec
+
+gem 'chef-provisioning', github: 'chef/chef-provisioning'
+
+group :development do
+  gem 'pry'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,166 @@
+GIT
+  remote: git://github.com/chef/chef-provisioning.git
+  revision: bc3b4c463a9cd43ad23261c0cb7b9b53ddb3eb37
+  specs:
+    chef-provisioning (0.19)
+      cheffish (~> 0.8)
+      inifile (~> 2.0)
+      net-scp (~> 1.0)
+      net-ssh (~> 2.0)
+      net-ssh-gateway (~> 1.2.0)
+      winrm (~> 1.2.0)
+
+PATH
+  remote: .
+  specs:
+    chef-provisioning-lxc (0.6)
+      chef (>= 12.0.3)
+      chef-provisioning
+      lxc-extra (~> 0.0, >= 0.0.3)
+      ruby-lxc (~> 1.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    akami (1.2.2)
+      gyoku (>= 0.4.0)
+      nokogiri
+    builder (3.2.2)
+    chef (12.0.3)
+      chef-zero (~> 3.2)
+      diff-lcs (~> 1.2, >= 1.2.4)
+      erubis (~> 2.7)
+      ffi-yajl (~> 1.2)
+      highline (~> 1.6, >= 1.6.9)
+      mixlib-authentication (~> 1.3)
+      mixlib-cli (~> 1.4)
+      mixlib-config (~> 2.0)
+      mixlib-log (~> 1.3)
+      mixlib-shellout (>= 2.0.0.rc.0, < 3.0)
+      net-ssh (~> 2.6)
+      net-ssh-multi (~> 1.1)
+      ohai (~> 8.0)
+      plist (~> 3.1.0)
+      pry (~> 0.9)
+    chef-zero (3.2.1)
+      ffi-yajl (~> 1.1)
+      hashie (~> 2.0)
+      mixlib-log (~> 1.3)
+      rack
+      uuidtools (~> 2.1)
+    cheffish (0.9.2)
+      chef-zero
+    coderay (1.1.0)
+    diff-lcs (1.2.5)
+    erubis (2.7.0)
+    ffi (1.9.6)
+    ffi-yajl (1.4.0)
+      ffi (~> 1.5)
+      libyajl2 (~> 1.2)
+    gssapi (1.0.3)
+      ffi (>= 1.0.1)
+    gyoku (1.2.2)
+      builder (>= 2.1.2)
+    hashie (2.1.2)
+    highline (1.7.1)
+    httpclient (2.6.0.1)
+    httpi (0.9.7)
+      rack
+    inifile (2.0.2)
+    ipaddress (0.8.0)
+    libyajl2 (1.2.0)
+    little-plugger (1.1.3)
+    logging (1.8.2)
+      little-plugger (>= 1.1.3)
+      multi_json (>= 1.8.4)
+    lxc-extra (0.0.3)
+      ruby-lxc
+    method_source (0.8.2)
+    mime-types (2.4.3)
+    mini_portile (0.6.2)
+    mixlib-authentication (1.3.0)
+      mixlib-log
+    mixlib-cli (1.5.0)
+    mixlib-config (2.1.0)
+    mixlib-log (1.6.0)
+    mixlib-shellout (2.0.1)
+    multi_json (1.10.1)
+    net-dhcp (1.3.2)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    net-ssh-gateway (1.2.0)
+      net-ssh (>= 2.6.5)
+    net-ssh-multi (1.2.0)
+      net-ssh (>= 2.6.5)
+      net-ssh-gateway (>= 1.2.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    nori (1.1.5)
+    ohai (8.1.1)
+      ffi (~> 1.9)
+      ffi-yajl (~> 1.1)
+      ipaddress
+      mime-types (~> 2.0)
+      mixlib-cli
+      mixlib-config (~> 2.0)
+      mixlib-log
+      mixlib-shellout (~> 2.0)
+      net-dhcp
+      rake (~> 10.1)
+      systemu (~> 2.6.4)
+      wmi-lite (~> 1.0)
+    plist (3.1.0)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rack (1.6.0)
+    rake (10.4.2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.0)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.0)
+    ruby-lxc (1.2.0)
+    rubyntlm (0.1.1)
+    savon (0.9.5)
+      akami (~> 1.0)
+      builder (>= 2.1.2)
+      gyoku (>= 0.4.0)
+      httpi (~> 0.9)
+      nokogiri (>= 1.4.0)
+      nori (~> 1.0)
+      wasabi (~> 1.0)
+    slop (3.6.0)
+    systemu (2.6.4)
+    uuidtools (2.1.5)
+    wasabi (1.0.0)
+      nokogiri (>= 1.4.0)
+    winrm (1.2.0)
+      gssapi (~> 1.0.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (~> 1.6, >= 1.6.1)
+      nokogiri (~> 1.5)
+      rubyntlm (~> 0.1.1)
+      savon (= 0.9.5)
+      uuidtools (~> 2.1.2)
+    wmi-lite (1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  chef-provisioning!
+  chef-provisioning-lxc!
+  pry
+  rake
+  rspec

--- a/chef-provisioning-lxc.gemspec
+++ b/chef-provisioning-lxc.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.email = 'dey.ranjib@gmail.com'
   s.homepage = 'https://github.com/opscode/chef-provisioning-lxc'
 
-  s.add_dependency 'chef'
-  s.add_dependency 'chef-provisioning', '~> 0.11'
+  s.add_dependency 'chef', '>= 12.0.3'
+  s.add_dependency 'chef-provisioning'
   s.add_dependency 'ruby-lxc', '~> 1.1'
   s.add_dependency 'lxc-extra', '~> 0.0', '>= 0.0.3'
 

--- a/lib/chef/provisioning/lxc_driver/driver.rb
+++ b/lib/chef/provisioning/lxc_driver/driver.rb
@@ -76,8 +76,13 @@ module LXCDriver
 
           #
           # Create the machine
-          #
-          ct.create(machine_options[:template], machine_options[:backingstore], machine_options[:devspecs], 0, machine_options[:template_options])
+          ct.create(
+            machine_options[:template],
+            machine_options[:backingstore],
+            machine_options[:devspecs] || {},
+            machine_options[:flags] || 0,
+            machine_options[:template_options] || []
+          )
 
           machine_spec.location = {
             'driver_url' => driver_url,
@@ -101,21 +106,9 @@ module LXCDriver
       end
 
       # Get stopped containers running
-      unless ct.running?
+      if ct.defined? and not ct.running?
         action_handler.perform_action "start lxc container #{machine_spec.location['name']} (state is #{ct.state})" do
-          # Have to shell out to lxc-start for now, ct.start holds server sockets open!
-          lxc_start = "lxc-start -d -n #{Shellwords.escape(machine_spec.location['name'])}"
-# TODO add ability to change options on start
-#          if machine_options[:config_file]
-#            lxc_start << " -f #{Shellwords.escape(machine_options[:config_file])}"
-#          end
-#          if machine_options[:extra_config]
-#            machine_options[:extra_config].each_pair do |key,value|
-#              lxc_start << " -s #{Shellwords.escape("#{key}=#{value}")}"
-#            end
-#          end
-          shell_out!(lxc_start)
-#          ct.start
+          ct.start
         end
       end
 

--- a/lib/chef/provisioning/lxc_driver/lxc_transport.rb
+++ b/lib/chef/provisioning/lxc_driver/lxc_transport.rb
@@ -1,6 +1,6 @@
 require 'chef/provisioning/transport'
 require 'lxc/extra'
-require 'chef/mixin/shell_out'
+require 'mixlib/shellout'
 require 'lxc/extra/proxy_client_side'
 require 'lxc/extra/proxy_server_side'
 require 'lxc/extra/channel'
@@ -8,148 +8,157 @@ require 'uri'
 require 'socket'
 
 class Chef
-module Provisioning
-module LXCDriver
-  class LXCTransport < Chef::Provisioning::Transport
-    @@active_transports = []
+  module Provisioning
+    module LXCDriver
+      class LXCTransport < Chef::Provisioning::Transport
+        @@active_transports = []
 
-    class LXCExecuteResult < Struct.new(:command, :options, :stdout, :stderr, :exitstatus)
-      def error!
-        raise "Error: '#{command}' failed with exit code #{exitstatus}.\nSTDOUT:#{stdout}\nSTDERR:#{stderr}" if exitstatus != 0
-      end
-    end
-
-    attr_reader :name, :options, :lxc_path
-
-    include Chef::Mixin::ShellOut
-
-    def initialize(name, lxc_path, options={})
-      @options = options
-      @name = name
-      @lxc_path = lxc_path
-      @port_forwards = {}
-      @@active_transports << self
-    end
-
-    def container
-      @container ||= LXC::Container.new(name, lxc_path)
-    end
-
-    def rootfs
-      container.config_item('lxc.rootfs')
-    end
-
-    def container_path(path)
-      File.join(rootfs, path)
-    end
-
-    def execute(command, options = {})
-      Chef::Log.info("Executing #{command} on #{name}")
-      container.execute(:timeout => (execute_timeout(options) || 0)) do
-        begin
-          # TODO support streaming (shell out needs work)
-          out = shell_out(command)
-          LXCExecuteResult.new(command, options, out.stdout, out.stderr, out.exitstatus)
-        rescue Exception => e
-          LXCExecuteResult.new('', e.message, -1)
+        class LXCExecuteResult < Struct.new(:command, :options, :stdout, :stderr, :exitstatus)
+          def error!
+            raise "Error: '#{command}' failed with exit code #{exitstatus}.\nSTDOUT:#{stdout}\nSTDERR:#{stderr}" if exitstatus != 0
+          end
         end
-      end
-    end
 
-    def make_url_available_to_remote(local_url)
-      uri = URI(local_url)
-      host = Socket.getaddrinfo(uri.host, uri.scheme, nil, :STREAM)[0][3]
-      if host == '127.0.0.1' || host == '::1'
-        unless @port_forwards[uri.port]
+        attr_reader :name, :options, :lxc_path
 
-          Chef::Log.debug("Forwarding container port #{uri.port} to local port #{uri.port}")
-          # Create the channel that will let the container and the host talk to each other
-          channel = LXC::Extra::Channel.new
+        include Chef::Mixin::ShellOut
 
-          # Start the container side of the proxy, listening for client connections
-          pid = container.attach do
+        def initialize(name, lxc_path, options={})
+          @options = options
+          @name = name
+          @lxc_path = lxc_path
+          @port_forwards = {}
+          @@active_transports << self
+        end
+
+        def container
+          @container ||= LXC::Container.new(name, lxc_path)
+        end
+
+        def rootfs
+          container.config_item('lxc.rootfs')
+        end
+
+        def container_path(path)
+          File.join(rootfs, path)
+        end
+
+        def execute(command, options = {})
+          timeout = options[:timeout] || 3600
+          Chef::Log.info("Executing #{command} on #{name}")
+          container.execute(timeout: timeout) do
+            cmd = Mixlib::ShellOut.new(command)
+            cmd.timeout = timeout
             begin
-              server = TCPServer.new(host, uri.port)
-              proxy = LXC::Extra::ProxyClientSide.new(channel, server)
-              proxy.start
+              cmd.run_command
+              LXCExecuteResult.new(command, {}, cmd.stdout, cmd.stderr, cmd.exitstatus)
+            rescue Errno::ENOENT => e
+              LXCExecuteResult.new(command, {} , '', e.message, 2)
+            end
+          end
+        end
+
+        def make_url_available_to_remote(local_url)
+          uri = URI(local_url)
+          host = Socket.getaddrinfo(uri.host, uri.scheme, nil, :STREAM)[0][3]
+          if host == '127.0.0.1' || host == '::1'
+            unless @port_forwards[uri.port]
+
+              Chef::Log.debug("Forwarding container port #{uri.port} to local port #{uri.port}")
+              # Create the channel that will let the container and the host talk to each other
+              channel = LXC::Extra::Channel.new
+
+              # Start the container side of the proxy, listening for client connections
+              pid = container.attach do
+                begin
+                  server = TCPServer.new(host, uri.port)
+                  proxy = LXC::Extra::ProxyClientSide.new(channel, server)
+                  proxy.start
+                rescue
+                  Chef::Log.error("ERROR in proxy (container side): #{$!}\n#{$!.backtrace.join("\n")}")
+                  raise
+                end
+              end
+
+              # Start the host side of the proxy, which contacts the real server
+              thread = Thread.new do
+                proxy = LXC::Extra::ProxyServerSide.new(channel) do
+                  TCPSocket.new(host, uri.port)
+                end
+                proxy.start
+              end
+
+              Chef::Log.debug("Forwarded #{uri.port} on container #{name} to local port #{uri.port}.  Container listener id PID #{pid}")
+
+              @port_forwards[uri.port] = [ pid, thread, channel ]
+            end
+
+          end
+          local_url
+        end
+
+        def read_file(path)
+          container.execute(wait: true) do
+            if File.exists?(container_path(path))
+              File.read(container_path(path))
+            end
+          end
+        end
+
+        def download_file(path, local_path)
+          Chef::Log.debug("Copying file #{path} from #{name} to local #{local_path}")
+          data = read_file(path)
+          File.open(local_path, 'w') do |f|
+            f.write(data)
+          end
+        end
+
+        def write_file(path, content)
+          container.execute(wait: true) do
+            File.open(path, 'w') do |f|
+              f.write(content)
+            end
+          end
+        end
+
+        def upload_file(local_path, path)
+          write_file(path, File.read(local_path))
+        end
+
+        def disconnect
+          @port_forwards.each_pair do |port, (pid, thread, channel)|
+            Chef::Log.debug("stopping port forward #{port} for container #{name}")
+            begin
+              Chef::Log.debug("Killing PID #{pid}")
+              Process.kill('KILL', pid)
             rescue
-              Chef::Log.error("ERROR in proxy (container side): #{$!}\n#{$!.backtrace.join("\n")}")
-              raise
+            end
+            begin
+              thread.kill
+            rescue
             end
           end
+          @port_forwards = {}
+          @@active_transports.delete(self)
+        end
 
-          # Start the host side of the proxy, which contacts the real server
-          thread = Thread.new do
-            proxy = LXC::Extra::ProxyServerSide.new(channel) do
-              TCPSocket.new(host, uri.port)
-            end
-            proxy.start
+        def available?
+          begin
+            execute('pwd')
+            true
+          rescue Exception =>e
+            false
           end
-
-          Chef::Log.debug("Forwarded #{uri.port} on container #{name} to local port #{uri.port}.  Container listener id PID #{pid}")
-
-          @port_forwards[uri.port] = [ pid, thread, channel ]
         end
 
-      end
-      local_url
-    end
-
-    def read_file(path)
-      if File.exists?(container_path(path))
-        File.read(container_path(path))
-      end
-    end
-
-    def download_file(path, local_path)
-      Chef::Log.debug("Copying file #{path} from #{name} to local #{local_path}")
-      FileUtils.cp_r(container_path(path), local_path)
-    end
-
-    def write_file(path, content)
-      File.open(container_path(path), 'w') do |f|
-        f.write(content)
-      end
-    end
-
-    def upload_file(local_path, path)
-      FileUtils.cp_r(local_path, container_path(path))
-    end
-
-    def disconnect
-      @port_forwards.each_pair do |port, (pid, thread, channel)|
-        Chef::Log.debug("stopping port forward #{port} for container #{name}")
-        begin
-          Chef::Log.debug("Killing PID #{pid}")
-          Process.kill('KILL', pid)
-        rescue
+        def self.disconnect_active_transports
+          @@active_transports.to_a.dup.each do |transport|
+            transport.disconnect
+          end
         end
-        begin
-          thread.kill
-        rescue
-        end
-      end
-      @port_forwards = {}
-      @@active_transports.delete(self)
-    end
-
-    def available?
-      begin
-        execute('pwd')
-        true
-      rescue Exception =>e
-        false
-      end
-    end
-
-    def self.disconnect_active_transports
-      @@active_transports.to_a.dup.each do |transport|
-        transport.disconnect
       end
     end
   end
-end
-end
 end
 
 at_exit do

--- a/lib/chef/provisioning/lxc_driver/lxc_transport.rb
+++ b/lib/chef/provisioning/lxc_driver/lxc_transport.rb
@@ -143,12 +143,7 @@ class Chef
         end
 
         def available?
-          begin
-            execute('pwd')
-            true
-          rescue Exception =>e
-            false
-          end
+          container.running?
         end
 
         def self.disconnect_active_transports

--- a/lib/chef/provisioning/lxc_driver/version.rb
+++ b/lib/chef/provisioning/lxc_driver/version.rb
@@ -1,7 +1,7 @@
 class Chef
-module Provisioning
-module LXCDriver
-  VERSION = '0.6'
-end
-end
+  module Provisioning
+    module LXCDriver
+      VERSION = '0.6'
+    end
+  end
 end

--- a/test/cookbooks/lxctests/recipes/simple.rb
+++ b/test/cookbooks/lxctests/recipes/simple.rb
@@ -1,6 +1,11 @@
 require 'chef/provisioning'
-require 'chef/provisioning/lxc_driver/lxc_provisioner'
-with_provisioner Chef::Provisioning::LXCDriver::LXCProvisioner.new
+require 'chef/provisioning/lxc_driver'
+::Chef::Config.from_file '/home/ranjib/workspace/foss/chef-provisioning-lxc/.chef/knife.rb'
+with_driver 'lxc'
 # default ubuntu template will install 14.04, where chef is not well tested, lets use 12.04
-with_provisioner_options 'template' => 'ubuntu', 'template_options'=>['-r','precise']
-machine 'simple'
+machine 'simple' do
+  machine_options(
+    template: 'download',
+    template_options: %w{-d ubuntu -a amd64 -r trusty}
+  )
+end


### PR DESCRIPTION
@jkeiser i have changed the execute output semantic. This is the first working version that does not implement streaming. IO objects cant be returned from container execute method since they are not serializable. We can implement Mixlib::ShellOut like live_stream though.

Im testing this based on the chef-provisioning master.

it will be nice to have a minimal spec suite for the machine resource :-), which lxc driver can use to check compatibility
