### PR TITLE
Test Kitchen support files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+pkg/
+
+# Berkshelf
+.vagrant
+/berks-cookbooks
+/cookbooks
+Berksfile.lock
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,28 @@
+---
+driver:
+  name: vagrant
+  customize:
+    memory: 4096
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-12.04
+  - name: ubuntu-14.04
+
+suites:
+  - name: default
+    run_list:
+      - recipe[lxctests::install_chef_provisioning]
+      - recipe[lxctests::simple]
+      - recipe[lxctests::simple2]
+    attributes: {
+      apt: {
+        compile_time_update: true
+      },
+      build-essential: {
+        compile_time: true
+      }
+    }
+

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,5 @@
+source 'https://supermarket.chef.io'
+
+group :integration do
+  cookbook 'lxctests', :path => './test/cookbooks/lxctests'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 gemfile
 gemspec
 
@@ -7,3 +7,6 @@ gem 'chef-provisioning', github: 'chef/chef-provisioning'
 group :development do
   gem 'pry'
 end
+
+gem 'test-kitchen'
+gem 'kitchen-vagrant'

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,10 @@ require 'bundler/gem_tasks'
 task :spec do
   require File.expand_path('spec/run')
 end
+
+begin
+  require 'kitchen/rake_tasks'
+  Kitchen::RakeTasks.new
+rescue LoadError
+  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+end

--- a/test/cookbooks/lxctests/metadata.rb
+++ b/test/cookbooks/lxctests/metadata.rb
@@ -1,0 +1,10 @@
+name             'lxctests'
+maintainer       'Chef Software, Inc.'
+maintainer_email 'cookbooks@chef.io'
+license          'Apache 2.0'
+description      'Installs/Configures lxctests'
+long_description 'Installs/Configures lxctests'
+version          '0.1.0'
+
+depends          'apt'
+depends          'build-essential'

--- a/test/cookbooks/lxctests/recipes/install_chef_provisioning.rb
+++ b/test/cookbooks/lxctests/recipes/install_chef_provisioning.rb
@@ -1,9 +1,9 @@
 include_recipe 'lxctests::install_lxc'
 
 chef_gem 'chef-provisioning' do
-        action :install
+  compile_time true
 end
 
 chef_gem 'chef-provisioning-lxc' do
-        action :install
+  compile_time true
 end

--- a/test/cookbooks/lxctests/recipes/install_lxc.rb
+++ b/test/cookbooks/lxctests/recipes/install_lxc.rb
@@ -1,36 +1,12 @@
-# Ubuntu 12, not Ubuntu 14
+include_recipe 'apt'
+include_recipe 'build-essential'
+
+# Ubuntu 14+ ships with fresh enough LXC
 if node['platform'] == 'ubuntu' && node['platform_version'].to_i == 12
-  execute 'apt-get update' do
+  apt_repository 'ppa:ubuntu-lxc/stable' do
     action :nothing
-  end.run_action(:run)
-
-  package 'python-software-properties' do
-    action :nothing
-  end.run_action(:install)
-
-  package 'make' do
-    action :nothing
-  end.run_action(:install)
+  end.run_action(:add)
 end
-
-execute 'add-apt-repository ppa:ubuntu-lxc/stable' do
-  action :nothing
-end.run_action(:run)
-
-execute 'apt-get update' do
-  action :nothing
-end.run_action(:run)
-
-# Needed for Ubuntu 14, not Ubuntu 12
-if node['platform'] == 'ubuntu' && node['platform_version'].to_i == 14
-  package 'ruby1.9.1-dev' do
-    action :nothing
-  end.run_action(:upgrade)
-end
-
-package 'lxc' do
-  action :nothing
-end.run_action(:upgrade)
 
 package 'lxc-dev' do
   action :nothing

--- a/test/cookbooks/lxctests/recipes/simple.rb
+++ b/test/cookbooks/lxctests/recipes/simple.rb
@@ -1,10 +1,13 @@
 require 'chef/provisioning'
-::Chef::Config.from_file '/home/ranjib/workspace/foss/chef-provisioning-lxc/.chef/knife.rb'
+
 with_driver 'lxc'
-# default ubuntu template will install 14.04, where chef is not well tested, lets use 12.04
+
+directory '/tmp/chef-repo'
+with_chef_local_server chef_repo_path: '/tmp/chef-repo'
+
 machine 'simple' do
   machine_options(
     template: 'download',
-    template_options: %w{-d ubuntu -a amd64 -r trusty}
+    template_options: %w( -d ubuntu -a amd64 -r trusty )
   )
 end

--- a/test/cookbooks/lxctests/recipes/simple2.rb
+++ b/test/cookbooks/lxctests/recipes/simple2.rb
@@ -1,11 +1,17 @@
 require 'chef/provisioning'
+
 with_driver 'lxc'
-# default ubuntu template will install 14.04, where chef is not well tested, lets use 12.04
-with_machine_options :template => 'ubuntu',
-                     :template_options => ['-r','precise'],
+
+directory '/tmp/chef-repo'
+with_chef_local_server chef_repo_path: '/tmp/chef-repo'
+
+with_machine_options :template => 'download',
+                     :template_options => %w( -d ubuntu -a amd64 -r trusty ),
                      :config_file => '/tmp/empty.conf',
                      :extra_config => { 'lxc.network.type' => 'empty' }
+
 file '/tmp/empty.conf' do
   content ''
 end
-machine 'simple'
+
+machine 'simple2'


### PR DESCRIPTION
Not sure if this is wanted in the repository, but I was trying to run tests and not all of the support files were available. I could remove the use of the `apt`/`build-essential` cookbooks if that is preferred.
